### PR TITLE
Rename repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # netscape
 
-Evaluating the **net**work/pathway regularization land**scape** for gene expression data
+Exploring the **net**work/pathway regularization land**scape** for gene expression data
 
-Overall goal of this project: explore network regularized methods for
+Overall goal of this project: evaluate network regularized methods for
 a variety of practical problems using a variety of biological networks.
 
 At present, this repo contains an adaptation of the pipeline used in

--- a/README.md
+++ b/README.md
@@ -1,18 +1,13 @@
-# netreg
+# netscape
 
-Evaluating various approaches to network/pathway regularization for gene expression data
+Evaluating the **net**work/pathway regularization land**scape** for gene expression data
 
-This is an adaptation of the pipeline used in [BioBombe](https://github.com/greenelab/BioBombe)
-for predicting gene alteration status using compressed TCGA gene expression data.
+Overall goal of this project: explore network regularized methods for
+a variety of practical problems using a variety of biological networks.
 
-Current goals of this project:
-  * Benchmark [PLIER](https://github.com/wgmao/PLIER) against the
-    current models (e.g. PCA, NMF) for gene alteration prediction
-  * Explore network regularized methods for gene alteration prediction
-    (e.g. graph LASSO as implemented
-    [here](https://github.com/suinleelab/attributionpriors/blob/master/graph/Graph_Attribution_Prior.ipynb),
-    or network-regularized NMF as implemented [here](https://github.com/raphael-group/netNMF-sc))
-    using a variety of biological networks.
+At present, this repo contains an adaptation of the pipeline used in
+[BioBombe](https://github.com/greenelab/BioBombe) for predicting gene
+alteration status using TCGA gene expression data.
 
 ## Setup
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,25 +1,29 @@
 name: netreg
 channels:
-  - bioconda
   - r
   - conda-forge
+  - pytorch
+  - bioconda
   - defaults
 dependencies:
   - bioconductor-qvalue=2.2.2
-  - dask=2.0.0
+  - dask=2.9.1
   - dask-ml=1.0.0
   - matplotlib=3.1.0
-  - numpy=1.16.4
+  - networkx=2.4
+  - numpy=1.16.5
   - pandas=0.24.2
-  - python=3.6.8
+  - python=3.6.9
   - pytest=5.0.0
+  - pytorch=1.2.0
   - r=3.6.0
   - r-argparse=2.0.1
+  - r-base=3.6.0
   - r-devtools=2.0.2
   - r-ggplot2=3.1.1
   - r-rcolorbrewer=1.1_2
   - scikit-learn=0.21.2
-  - scipy=1.2.1
+  - scipy=1.3.2
   - seaborn=0.9.0
-  - r-base=3.6.0
+  - torchvision=0.4.0
 


### PR DESCRIPTION
Closes #5.

My current name conflicts with [another related repository](https://github.com/dirmeier/netReg) which I'm now confusingly using in some of my experiments, so I think now is the time to change the name.

A Google search for "netscape bioinformatics" doesn't bring up anything relevant, although of course searching for "netscape" on its own may be less successful :laughing:

Once this PR gets approved, I'll change the repo name.